### PR TITLE
Use platform specific directory separators to allow tests to be run o…

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -1,9 +1,14 @@
 import { exec } from 'child_process'
 import * as assert from 'assert'
+import { join } from 'path'
 
 console.log(__dirname)
 
-exec('../node_modules/.bin/tslint -c ./tslint.json -r ../ ./*.ts', { cwd: __dirname }, (error, stdout, stderr) => {
+const tslintBin = join('..', 'node_modules', '.bin', 'tslint')
+const tslintConfig = join('.', 'tslint.json')
+const tsFiles = join('.', '*.ts');
+
+exec(`${tslintBin} -c ${tslintConfig} -r .. ${tsFiles}`, { cwd: __dirname }, (error, stdout, stderr) => {
   assert.equal(stdout, `
 ERROR: case1.ts[1, 1]: circular import detected: case1.ts -> case1.1.ts -> case1.ts
 ERROR: case1.ts[2, 1]: circular import detected: case1.ts -> case1.2.ts -> case1.ts


### PR DESCRIPTION
…n Windows. Part of #4 

Tested against Windows 10 and reasonably up to date Gentoo Linux.