### PR TITLE
Allow execution on node 5.x. Part of #4

### DIFF
--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -77,7 +77,7 @@ class NoCircularImportsWalker extends Lint.RuleWalker {
 
   private getCycle(moduleName: string, accumulator: string[] = []): string[] {
     if (!imports.get(moduleName)) return []
-    if (accumulator.includes(moduleName)) return accumulator
+    if (accumulator.indexOf(moduleName) !== -1) return accumulator
     return Array.from(imports.get(moduleName) !.values()).reduce((_prev, _) => {
       const c = this.getCycle(_, accumulator.concat(moduleName))
       return c.length ? c : []

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/bcherny/tslint-no-circular-imports.git"
   },
   "dependencies": {
-    "@types/node": "^8.0.28",
+    "@types/node": "^4.2.23",
     "tslint": "^5.7.0",
     "typescript": "^2.5.2"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,10 @@
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "lib": [
-      "es2015",
-      "es2016.array.include"
+      "es5",
+      "es2015.core",
+      "es2015.collection",
+      "es2015.iterable"
     ],
     "module": "commonjs",
     "moduleResolution": "node",
@@ -16,7 +18,7 @@
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2015",
+    "target": "es5",
     "types": [
       "node"
     ]


### PR DESCRIPTION
Visual Studio 2017 comes bundled with node v5.4.1 (based on installs I've checked). This seems to be the default node version used for running npm, gulp and grunt tasks in the Task Runner Explorer, as well as typescript language service plugins.

This PR allows the plugin to run on node v5.

* I've replaced methods that don't exist yet (`Array.prototype.includes`)
* Unsupported syntax is covered by building to ES5
* I've tried to trim down the typings as best as I can too, though they may not be perfect

I've tested this on Node 6 with Gentoo Linux and Node 5 and 8 on Windows 10 (with #5 in place).