### PR TITLE
Move node typings to dev dependencies. Part of #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "url": "git+https://github.com/bcherny/tslint-no-circular-imports.git"
   },
   "dependencies": {
-    "@types/node": "^4.2.23",
     "tslint": "^5.7.0",
     "typescript": "^2.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^4.2.23"
   }
 }


### PR DESCRIPTION
Node typings aren't needed after build time, and can conflict with typings in other projects