### PR TITLE
 Moved tslint and typescript to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "type": "git",
     "url": "git+https://github.com/bcherny/tslint-no-circular-imports.git"
   },
-  "dependencies": {
-    "tslint": "^5.7.0",
-    "typescript": "^2.5.2"
+  "peerDependencies": {
+    "tslint": ">=5.0.0",
+    "typescript": ">=2.1.0"
   },
   "devDependencies": {
-    "@types/node": "^4.2.23"
+    "@types/node": "^4.2.23",
+    "tslint": "^5.7.0",
+    "typescript": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "url": "git+https://github.com/bcherny/tslint-no-circular-imports.git"
   },
   "dependencies": {
-    "@types/node": "^4.2.23",
     "tslint": "^5.7.0",
     "typescript": "^2.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^4.2.23"
   }
 }


### PR DESCRIPTION
As far as I can tell these dependencies should come from the project using the plugin at runtime.
I've moved TS and tslint, as they are, into dev dependencies for tests etc, and added more lenient peer dependencies for them when installed into other projects.

I'm not fixing a particular bug here, but it seemed like a reasonable thing to do after I changed the node typings.