### PR TITLE
Clear stored imports for a file before reprocessing

### DIFF
--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -78,10 +78,13 @@ class NoCircularImportsWalker extends Lint.RuleWalker {
   private getCycle(moduleName: string, accumulator: string[] = []): string[] {
     if (!imports.get(moduleName)) return []
     if (accumulator.indexOf(moduleName) !== -1) return accumulator
-    return Array.from(imports.get(moduleName) !.values()).reduce((_prev, _) => {
-      const c = this.getCycle(_, accumulator.concat(moduleName))
-      return c.length ? c : []
-    }, [] as string[])
+
+    for(const imp of Array.from(imports.get(moduleName) !.values())) {
+      const c = this.getCycle(imp, accumulator.concat(moduleName))
+      if(c.length) return c
+    }
+
+    return []
   }
 
 }

--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -50,10 +50,10 @@ class NoCircularImportsWalker extends Lint.RuleWalker {
     this.addToGraph(resolvedThisFileName, resolvedImportFileName)
 
     // check for cycles
-    if (this.hasCycle(resolvedThisFileName)) {
+    if (this.hasCycle(resolvedThisFileName, resolvedImportFileName)) {
       this.addFailure(
         this.createFailure(node.getStart(), node.getWidth(), `${Rule.FAILURE_STRING}: ${
-          this.getCycle(resolvedThisFileName).concat(resolvedThisFileName).map(_ => basename(_)).join(' -> ')
+          this.getCycle(resolvedThisFileName, resolvedImportFileName).concat(resolvedThisFileName).map(_ => basename(_)).join(' -> ')
         }`)
       )
     }
@@ -71,17 +71,23 @@ class NoCircularImportsWalker extends Lint.RuleWalker {
     imports.get(thisFileName)!.add(importCanonicalName)
   }
 
-  private hasCycle(moduleName: string): boolean {
-    return this.getCycle(moduleName).length > 0
+  private hasCycle(moduleName: string, startFromImportName: string): boolean {
+    return this.getCycle(moduleName, startFromImportName).length > 0
   }
 
-  private getCycle(moduleName: string, accumulator: string[] = []): string[] {
+  private getCycle(moduleName: string, startFromImportName?: string | undefined, accumulator: string[] = []): string[] {
     if (!imports.get(moduleName)) return []
     if (accumulator.indexOf(moduleName) !== -1) return accumulator
 
-    for(const imp of Array.from(imports.get(moduleName) !.values())) {
-      const c = this.getCycle(imp, accumulator.concat(moduleName))
+    if(startFromImportName !== undefined && imports.has(startFromImportName)) {
+      const c = this.getCycle(startFromImportName, undefined, accumulator.concat(moduleName))
       if(c.length) return c
+    }
+    else {
+      for(const imp of Array.from(imports.get(moduleName) !.values())) {
+        const c = this.getCycle(imp, undefined, accumulator.concat(moduleName))
+        if(c.length) return c
+      }
     }
 
     return []

--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -18,6 +18,8 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const resolvedFile = resolve(sourceFile.fileName)
+    imports.delete(resolvedFile)
     return this.applyWithWalker(new NoCircularImportsWalker(sourceFile, this.getOptions()))
   }
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -27,3 +27,5 @@ function lintFile(fileName: string, content: string) {
 
 assert.equal(lintFile('./a.ts', 'import "./b"\nimport "./c"').errorCount, 0)
 assert.equal(lintFile('./b.ts', 'import "./a"').errorCount, 1)
+assert.equal(lintFile('./b.ts', '').errorCount, 0)
+assert.equal(lintFile('./a.ts', 'import "./b"').errorCount, 0)

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,6 +2,8 @@ import { exec } from 'child_process'
 import * as assert from 'assert'
 import { join } from 'path'
 
+import { Linter, Configuration } from 'tslint'
+
 console.log(__dirname)
 
 const tslintBin = join('..', 'node_modules', '.bin', 'tslint')
@@ -15,3 +17,13 @@ ERROR: case1.ts[2, 1]: circular import detected: case1.ts -> case1.2.ts -> case1
 
 `)
 })
+
+const config = Configuration.findConfiguration(join(__dirname, tslintConfig)).results
+function lintFile(fileName: string, content: string) {
+  const linter = new Linter({ fix: false })
+  linter.lint(fileName, content, config)
+  return linter.getResult()
+}
+
+assert.equal(lintFile('./a.ts', 'import "./b"\nimport "./c"').errorCount, 0)
+assert.equal(lintFile('./b.ts', 'import "./a"').errorCount, 1)


### PR DESCRIPTION
Part of #4.

Using `tslint-language-service`, this plugin is loaded once and will be run multiple times against the same file as they are updated. Each time, a new instance of the linter will be created (presumably that means a new instance of the rule, but I haven't confirmed).

Previously the imports picked up were never cleared so they accumulate indefinitely (meaning cycle errors are not cleared when they are fixed). This PR refreshes the stored imports for a file each time the file is linted again.