### PR TITLE
Follow 'export from' statements

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -29,3 +29,6 @@ assert.equal(lintFile('./a.ts', 'import "./b"\nimport "./c"').errorCount, 0)
 assert.equal(lintFile('./b.ts', 'import "./a"').errorCount, 1)
 assert.equal(lintFile('./b.ts', '').errorCount, 0)
 assert.equal(lintFile('./a.ts', 'import "./b"').errorCount, 0)
+
+assert.equal(lintFile('./x.ts', 'export * from "./y"').errorCount, 0)
+assert.equal(lintFile('./y.ts', 'export * from "./x"').errorCount, 1)


### PR DESCRIPTION
This PR follows `export * from module` and `export { ... } from module` statements as well as standard import statements. It also adds a test for this