### PR TITLE
Improve performance by quickly checking first for any cycle

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -17,30 +17,30 @@ exec(`${tslintBin} -p ${tsconfig} -c ${tslintConfig} -r .. -t ${tslintFormat} ${
   assert.deepEqual(actual, [
     // case1
     {
-      failure: 'circular import detected: case1.ts -> case1.1.ts -> case1.ts',
+      failure: 'circular import detected: case1.ts -> case1.2.ts -> case1.ts',
       name: join(__dirname, 'case1.ts')
     },
     {
-      failure: 'circular import detected: case1.ts -> case1.2.ts -> case1.ts',
-      name: join(__dirname, 'case1.ts')
+      failure: 'circular import detected: case1.1.ts -> case1.ts -> case1.1.ts',
+      name: join(__dirname, 'case1.1.ts')
     },
 
     // case2
     {
-      failure: 'circular import detected: case2/b.ts -> case2/a.ts -> case2/b.ts',
-      name: join(__dirname, 'case2/b.ts')
+      failure: 'circular import detected: case2/a.ts -> case2/b.ts -> case2/a.ts',
+      name: join(__dirname, 'case2/a.ts')
     },
 
     // case3
     {
-      failure: 'circular import detected: case3/b.ts -> case3/a.ts -> case3/b.ts',
-      name: join(__dirname, 'case3/b.ts')
+      failure: 'circular import detected: case3/a.ts -> case3/b.ts -> case3/a.ts',
+      name: join(__dirname, 'case3/a.ts')
     },
 
     // case4
     {
-      failure: 'circular import detected: case4/index.ts -> case4/a.ts -> case4/index.ts',
-      name: join(__dirname, 'case4/index.ts')
+      failure: 'circular import detected: case4/a.ts -> case4/index.ts -> case4/a.ts',
+      name: join(__dirname, 'case4/a.ts')
     }
   ])
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "preserveConstEnums": true,
+    "downlevelIteration": true,
     "pretty": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
The job did not finish on the Angular CLI (which is quite large), but with this upgrade
it finishes in a little over 10 seconds on my machine.

Also we only check for cycles once per file (instead of checking for every import).

The tests had to be changed because the order from TSLint seems to have changed
with the new algorithm. case1.1 is ran after case1 and so will not detect the
cycle before case1.1 (and will report case1.1 first). Same goes for the other
tests.