### PR TITLE
Added search-depth-limit parameter

### DIFF
--- a/test/case-long-stack/four.ts
+++ b/test/case-long-stack/four.ts
@@ -1,0 +1,1 @@
+import * as one from "./one";

--- a/test/case-long-stack/one.ts
+++ b/test/case-long-stack/one.ts
@@ -1,0 +1,1 @@
+import * as two from "./two";

--- a/test/case-long-stack/three.ts
+++ b/test/case-long-stack/three.ts
@@ -1,0 +1,1 @@
+import * as three from "./three";

--- a/test/case-long-stack/two.ts
+++ b/test/case-long-stack/two.ts
@@ -1,0 +1,1 @@
+import * as two from "./two";

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -1,6 +1,8 @@
 {
   "rulesDirectory": ["../"],
   "rules": {
-    "no-circular-imports": true
+    "no-circular-imports": [true, {
+      "search-depth-limit": 3
+    }]
   }
 }


### PR DESCRIPTION
Limits the depth of cycle reporting to a fixed to a fixied size limit for a list of files.
This helps improve performance, as most cycles do not surpass a few related files.

As I mentioned in the issue, we could theoretically fix the crashes by switching to an iterative solution. This is still a desirable change IMO because erroring files will do so faster.

Fixes #18 (recreation of #20 but with a good git history)