### PR TITLE
Fix "RangeError: Maximum call stack size exceeded"

### DIFF
--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -115,6 +115,9 @@ function walk(context: Lint.WalkContext<Options>) {
     if (!node.moduleSpecifier) {
       return
     }
+    if (!ts.isSourceFile(node.parent)) {
+      return
+    }
     const fileName = node.parent.fileName
 
     if (!ts.isStringLiteral(node.moduleSpecifier)) {

--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -153,8 +153,8 @@ function walk(context: Lint.WalkContext<Options>) {
     for (const imp of Array.from(moduleImport.keys())) {
       const c = getAllCycles(imp, accumulator.concat(moduleName), iterationDepth + 1)
 
-      if (c.length)
-        all.push(...c)
+      for (const cycle of c)
+        all.push(cycle)
     }
 
     return all


### PR DESCRIPTION
## Spread operator

The spread operator on line [153](https://github.com/bcherny/tslint-no-circular-imports/blob/4756e5fac3f8bfa036d1c0e77c9156386c99bca5/noCircularImportsRule.ts#L154) sometimes causes a "RangeError: Maximum call stack size exceeded" error.
My suggestion is to replace it with an ordinary for-in loop.

See also here:
https://stackoverflow.com/questions/22123769/rangeerror-maximum-call-stack-size-exceeded-why

Here is the original error:

```
The 'no-circular-imports' rule threw an error in '....ts':
RangeError: Maximum call stack size exceeded
    at getAllCycles (...\tslint-no-circular-imports\noCircularImportsRule.js:188:30)
    at walk (...\tslint-no-circular-imports\noCircularImportsRule.js:120:25)
    at Rule.AbstractRule.applyWithFunction (...\tslint-no-circular-imports\node_modules\tslint\lib\language\rule\abstractRule.js:39:9)
    at Rule.applyWithProgram (...\tslint-no-circular-imports\noCircularImportsRule.js:66:21)
    at Linter.applyRule (...\node_modules\tslint\lib\linter.js:206:29)
    at ...\node_modules\tslint\lib\linter.js:150:85
    at Object.flatMap (...\node_modules\tslint\lib\utils.js:160:29)
    at Linter.getAllFailures (...\node_modules\tslint\lib\linter.js:150:32)
    at Linter.lint (...\node_modules\tslint\lib\linter.js:105:33)
    at ...\node_modules\tslint\lib\runner.js:214:32
```

## Type check

I also asserted `node.parent` to be of type `SourceFile`.
I get an error without that check because node.parent can also be of type `ModuleBlock` which would not have a property `fileName`.

```
noCircularImportsRule.ts:118:34 - error TS2339: Property 'fileName' does not exist on type 'ModuleBlock | SourceFile'.
      Property 'fileName' does not exist on type 'ModuleBlock'.

    118     const fileName = node.parent.fileName
                                         ~~~~~~~~
```