### PR TITLE
Add option to exclude interfaces and type aliases from circular imports

### DIFF
--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -12,11 +12,17 @@ interface Options {
   /**
    * Maximum search depth to check for in generating a list of all cycles.
    */
-  searchDepthLimit: number
+  searchDepthLimit: number,
+
+  /**
+   * Include or ignore circular imports caused by interfaces and type aliases
+   */
+  ignoreTypeImports: boolean,
 }
 
 const OPTION_SEARCH_DEPTH_LIMIT = 'search-depth-limit'
 const OPTION_SEARCH_DEPTH_LIMIT_DEFAULT = 50
+const OPTION_IGNORE_TYPE_IMPORTS = true
 
 export class Rule extends Lint.Rules.TypedRule {
   static FAILURE_STRING = 'circular import detected'
@@ -60,7 +66,10 @@ export class Rule extends Lint.Rules.TypedRule {
       {
         compilerOptions,
         rootDir: compilerOptions.rootDir || process.cwd(),
-        searchDepthLimit: ruleArguments['search-depth-limit'] || OPTION_SEARCH_DEPTH_LIMIT
+        searchDepthLimit: ruleArguments['search-depth-limit'] || OPTION_SEARCH_DEPTH_LIMIT,
+        ignoreTypeImports: ruleArguments['ignore-type-imports'] !== undefined
+            ? ruleArguments['ignore-type-imports']
+            : OPTION_IGNORE_TYPE_IMPORTS
       },
       program.getTypeChecker())
   }
@@ -72,14 +81,14 @@ const imports = new Map<string, Map<string, ts.Node>>()
 const found = new Set<string>()
 const nodeModulesRe = new RegExp(`\\${sep}node_modules\\${sep}`)
 
-function walk(context: Lint.WalkContext<Options>) {
+function walk(context: Lint.WalkContext<Options>, tc: ts.TypeChecker) {
   // Instead of visiting all children, this is faster. We know imports are statements anyway.
   context.sourceFile.statements.forEach(statement => {
     // export declarations seem to be missing from the current SyntaxWalker
     if (ts.isExportDeclaration(statement)) {
-        visitImportOrExportDeclaration(statement)
+        visitImportOrExportDeclaration(statement, tc)
     } else if (ts.isImportDeclaration(statement)) {
-        visitImportOrExportDeclaration(statement)
+        visitImportOrExportDeclaration(statement, tc)
     }
   })
 
@@ -108,7 +117,7 @@ function walk(context: Lint.WalkContext<Options>) {
     }
   }
 
-  function visitImportOrExportDeclaration(node: ts.ImportDeclaration | ts.ExportDeclaration) {
+  function visitImportOrExportDeclaration(node: ts.ImportDeclaration | ts.ExportDeclaration, tc: ts.TypeChecker) {
     if (!node.parent || !ts.isSourceFile(node.parent)) {
       return
     }
@@ -134,6 +143,12 @@ function walk(context: Lint.WalkContext<Options>) {
     // Skip node modules entirely. We use this after resolution to support path mapping in the
     // tsconfig.json (which could override imports from/to node_modules).
     if (nodeModulesRe.test(resolvedImportFileName)) {
+      return
+    }
+
+    if (context.options.ignoreTypeImports
+        && ts.isImportDeclaration(node)
+        && isInterfaceOrTypeAliasImported(node, tc)) {
       return
     }
 
@@ -188,6 +203,40 @@ function checkCycle(moduleName: string): boolean {
       ...Array.from((imports.get(current) || new Map).keys())
               .filter(i => !accumulator.has(i))
     )
+  }
+
+  return false
+}
+
+function isInterfaceOrTypeAliasImported(node: ts.ImportDeclaration, tc: ts.TypeChecker): boolean {
+  if (node.importClause === undefined) {
+    return false
+  }
+
+  if (node.importClause.name !== undefined) {
+    return checkImportKind(node.importClause.name, tc)
+  } else if (node.importClause.namedBindings !== undefined && !ts.isNamespaceImport(node.importClause.namedBindings)) {
+    // Check if all imports are interfaces and types, and if so, return true
+    return node.importClause.namedBindings.elements.map(binding => {
+      return checkImportKind(binding.name, tc)
+    }).every(isTypeDeclaration => isTypeDeclaration === true)
+  }
+
+  return false
+}
+
+function checkImportKind(name: ts.Identifier, tc: ts.TypeChecker): boolean {
+  const symbol = tc.getSymbolAtLocation(name)
+
+  if (symbol === undefined) {
+    return false
+  }
+
+  const { declarations } = tc.getAliasedSymbol(symbol)
+
+  if (declarations !== undefined && declarations.length !== 0) {
+    const declaration = declarations[0]
+    return ts.isInterfaceDeclaration(declaration) || ts.isTypeAliasDeclaration(declaration)
   }
 
   return false

--- a/test/case-interfaces/a.ts
+++ b/test/case-interfaces/a.ts
@@ -1,0 +1,2 @@
+import { Interf } from './b';
+export default Interf;

--- a/test/case-interfaces/b.ts
+++ b/test/case-interfaces/b.ts
@@ -1,0 +1,5 @@
+import './a';
+
+export interface Interf {
+    
+}

--- a/test/case-type-aliases/a.ts
+++ b/test/case-type-aliases/a.ts
@@ -1,0 +1,2 @@
+import { TypeAl } from './b';
+export default TypeAl;

--- a/test/case-type-aliases/b.ts
+++ b/test/case-type-aliases/b.ts
@@ -1,0 +1,3 @@
+import 'a';
+
+export type TypeAl = any;

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -2,7 +2,8 @@
   "rulesDirectory": ["../"],
   "rules": {
     "no-circular-imports": [true, {
-      "search-depth-limit": 3
+      "search-depth-limit": 3,
+      "ignore-type-imports": true
     }]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/bcherny/tslint-no-circular-imports/issues/19