### PR TITLE
feat: Allow circular dependencies for .d.ts files

### DIFF
--- a/noCircularImportsRule.ts
+++ b/noCircularImportsRule.ts
@@ -119,6 +119,9 @@ function walk(context: Lint.WalkContext<Options>) {
       return
     }
     const fileName = node.parent.fileName
+    if(fileName.endsWith('.d.ts')) {
+      return
+    }
 
     if (!ts.isStringLiteral(node.moduleSpecifier)) {
       return


### PR DESCRIPTION
Hello @bcherny ,
Great lib !! 
In my case I want to use the no-circular-dependency for my react component. 

Since I'm using graphql and typescript, I have circular dependencies in my types.  

Also, circular dependencies generate errors at runtime, so I thought that we could ignore the pure typescript file. 

What do you think ? Is there a way to make this optional adding a rule like "ignore declaration files ?" ?